### PR TITLE
Revert automatic update of README.md by arcaflow-docsgen arcabot

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ run an fio workload
         </details><details><summary>ioengine (<code>enum[string]</code>)</summary>
         <table><tbody><tr><th>Name:</th><td>IO Engine</td></tr><tr><th>Description:</th><td width="500">Defines how the job issues IO to the file.</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>enum[string]</code></td><tr><td colspan="2">
         <details><summary>Values</summary>
-            <ul><li><strong><code>libaio</code>:</strong> libaio</li><li><strong><code>psync</code>:</strong> psync</li><li><strong><code>sync</code>:</strong> sync</li><li><strong><code>windowsaio</code>:</strong> windowsaio</li><li><strong><code>{&#39;psync&#39;, &#39;sync&#39;}</code>:</strong> _sync_io_engines</li><li><strong><code>{&#39;windowsaio&#39;, &#39;libaio&#39;}</code>:</strong> _async_io_engines</li></ul>
+            <ul><li><strong><code>libaio</code>:</strong> libaio</li><li><strong><code>psync</code>:</strong> psync</li><li><strong><code>sync</code>:</strong> sync</li><li><strong><code>windowsaio</code>:</strong> windowsaio</li><li><strong><code>{&#39;sync&#39;, &#39;psync&#39;}</code>:</strong> _sync_io_engines</li><li><strong><code>{&#39;windowsaio&#39;, &#39;libaio&#39;}</code>:</strong> _async_io_engines</li></ul>
         </details>
     </td>
 </tr></tbody></table>

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ run an fio workload
         </details><details><summary>ioengine (<code>enum[string]</code>)</summary>
         <table><tbody><tr><th>Name:</th><td>IO Engine</td></tr><tr><th>Description:</th><td width="500">Defines how the job issues IO to the file.</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>enum[string]</code></td><tr><td colspan="2">
         <details><summary>Values</summary>
-            <ul><li><strong><code>libaio</code>:</strong> libaio</li><li><strong><code>psync</code>:</strong> psync</li><li><strong><code>sync</code>:</strong> sync</li><li><strong><code>windowsaio</code>:</strong> windowsaio</li><li><strong><code>{&#39;sync&#39;, &#39;psync&#39;}</code>:</strong> _sync_io_engines</li><li><strong><code>{&#39;windowsaio&#39;, &#39;libaio&#39;}</code>:</strong> _async_io_engines</li></ul>
+            <ul><li><strong><code>libaio</code>:</strong> libaio</li><li><strong><code>psync</code>:</strong> psync</li><li><strong><code>sync</code>:</strong> sync</li><li><strong><code>windowsaio</code>:</strong> windowsaio</li><li><strong><code>{&#39;libaio&#39;, &#39;windowsaio&#39;}</code>:</strong> _async_io_engines</li><li><strong><code>{&#39;psync&#39;, &#39;sync&#39;}</code>:</strong> _sync_io_engines</li></ul>
         </details>
     </td>
 </tr></tbody></table>


### PR DESCRIPTION
## Changes introduced with this PR

The `arcaflow-docsgen` bot produces automatic updates to the `README.md` file based on the plugin schema.  Unfortunately, for certain items in the schema, the resulting documentation items appear in a random order (this is a feature of mappings in Go and other languages).  This means that each time the bot runs, it may detect what it thinks is a change in the documentation, and it then proposes an update.  This is just annoying in the case of a PR branch, but it results in the CI failing when it occurs on the `main` branch.

Unfortunately, there is nothing we can do about this without tearing into the implementation of the bot.  The bot _should_ be producing a deterministic order (e.g., alphabetical...), so that it won't produce these spurious failures.  (And, of course, the bot shouldn't be proposing updates to the `main` branch.)

Since the CI for this repo is currently failing due to the operation of `arcaflow-docsgen`, this PR reverts the contents of the `README.md` to its previous revision (which contains the same text in a different order), in the hopes that it will mollify the bot (for now).

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).