### PR TITLE
Remove unneeded schema elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ run an fio workload
         </details><details><summary>ioengine (<code>enum[string]</code>)</summary>
         <table><tbody><tr><th>Name:</th><td>IO Engine</td></tr><tr><th>Description:</th><td width="500">Defines how the job issues I/O to the file. Default is sync.</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>enum[string]</code></td><tr><td colspan="2">
         <details><summary>Values</summary>
-            <ul><li><strong><code>libaio</code>:</strong> libaio</li><li><strong><code>psync</code>:</strong> psync</li><li><strong><code>sync</code>:</strong> sync</li><li><strong><code>windowsaio</code>:</strong> windowsaio</li><li><strong><code>{&#39;sync&#39;, &#39;psync&#39;}</code>:</strong> _sync_io_engines</li><li><strong><code>{&#39;windowsaio&#39;, &#39;libaio&#39;}</code>:</strong> _async_io_engines</li></ul>
+            <ul><li><strong><code>libaio</code>:</strong> libaio</li><li><strong><code>psync</code>:</strong> psync</li><li><strong><code>sync</code>:</strong> sync</li><li><strong><code>windowsaio</code>:</strong> windowsaio</li></ul>
         </details>
     </td>
 </tr></tbody></table>

--- a/arcaflow_plugin_fio/fio_schema.py
+++ b/arcaflow_plugin_fio/fio_schema.py
@@ -48,8 +48,6 @@ class IoSubmitMode(str, enum.Enum):
 
 
 class IoEngine(str, enum.Enum):
-    _sync_io_engines = {"sync", "psync"}
-    _async_io_engines = {"libaio", "windowsaio"}
     sync = "sync"
     psync = "psync"
     libaio = "libaio"
@@ -57,9 +55,6 @@ class IoEngine(str, enum.Enum):
 
     def __str__(self) -> str:
         return self.value
-
-    def is_sync(self) -> bool:
-        return self.value in self._sync_io_engines
 
 
 duration_pattern_string = r"[1-9][0-9]*(?:d|h|m|s|ms|us)?"


### PR DESCRIPTION
## Changes introduced with this PR

This PR updates the branch underlying #40 by removing some currently-unneeded schema elements which happen to be making the `docsgen` result unstable.  (See #39.)

(Even if you are uninterested, @dustinblack, this PR served as an excellent vehicle for testing a change to the `docsgen` workflow (see https://github.com/arcalot/arcaflow-docsgen/pull/43).)

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).